### PR TITLE
Aria2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ This tool was written thanks to ESA well documented scihub API : https://scihub.
 
 To use this tool, you need a scihub account obtained a long time in advance (see below). If you do not have such an account, or if you want to try a faster access, you might consider downloading the products from the [French collaborative ground segment PEPS](https://github.com/olivierhagolle/peps_download).
 
-### wget
-To use it, you need *wget* installed. I guess it goes with any linux distribution. For windows, I don't know, but maybe someone can tell.
+### wget /aria2
+To use it, you need either to have *wget* or *aria2* installed. I guess it goes with any linux distribution. For windows users, first install aria2 (https://aria2.github.io).
 If your download stops for a network issue, you can restart S2-download, as wget knows how to resume without havind to download everything again. Wget doesnot download the products already fully downloaded (unlesss you have unzipped them).
 
 ### Proxy

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Here are a few examples for Sentinel-2
 
 `python  Sentinel_download.py --lat 43.6 --lon 1.44 -a apihub.txt -o 51 -s S2`
 
+- To download all products over Toulouse taken from Path 51 with aria2 for windows
+
+`python  Sentinel_download.py --downloader="aria2" --lat 43.6 --lon 1.44 -a apihub.txt -o 51 -s S2`
+
 - To see all products over Toulouse taken from Path 51, but without downloading, thanks to -n option
 
 `python  Sentinel_download.py --lat 43.6 --lon 1.44 -a apihub.txt -o 51 -n -s S2`

--- a/apihub.txt
+++ b/apihub.txt
@@ -1,1 +1,1 @@
-guest guest
+michel michel123

--- a/apihub.txt
+++ b/apihub.txt
@@ -1,1 +1,1 @@
-michel michel123
+guest guest


### PR DESCRIPTION
Dear Olivier,

please find a first version of Aria2 support for your stupendous tool.
Aria2 is an open-source cross platform downloader (Linux, Windows, Android).

The user specifies that he is using this download with this option:'--downloader aria2'. By default, it still uses wget.

I had to make a slight modification of the originals URLs so that it could work on Windows, but I am not sure it behaves the same way with aria2 on Linux. Line 235: link=link.replace('/\\$value','/$value')

Also, at the beginning of the script, I had to supress the catalog file if it exists, otherwise Aria2 creates a new file called 'query_results.xml.1', .2, etc... (lines 170-171)

I hope it's all ok!



